### PR TITLE
Rstrip lines for null characters

### DIFF
--- a/processor.py
+++ b/processor.py
@@ -99,7 +99,7 @@ class parosProcessor:
             # Do not allow a single block of more than the number of lines
             # specified in self.MAXIMUM_UPLOAD_SIZE
             while line_counter <= self.MAXIMUM_UPLOAD_SIZE:
-                lp_str = f.readline()
+                lp_str = f.readline().rstrip(b'\x00')
                 if not lp_str:
                     # Arrived at the end of the file
                     break


### PR DESCRIPTION
Handles `readline()` returning a string of null chars instead of an empty string.

<img width="682" height="238" alt="image" src="https://github.com/user-attachments/assets/97baad27-2d0d-4c7d-8ee1-61787f9cfc7f" />
